### PR TITLE
Update Gp6.deb url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O libssl.deb http://security.ubuntu.com/ubuntu/pool/universe/o/openssl
 RUN dpkg -i libssl.deb
 RUN wget -O libportaudio0.deb http://mirrors.kernel.org/ubuntu/pool/universe/p/portaudio/libportaudio0_18.1-7.1_i386.deb
 RUN dpkg -i libportaudio0.deb
-RUN wget -O gp6.deb https://www.guitar-pro.com/download.php?idfile=gp6_linux
+RUN wget -O gp6.deb https://downloads.guitar-pro.com/gp6/gp6-full-linux-r11686.deb
 RUN dpkg -i gp6.deb || true
 # Fix broken things
 RUN apt-get install -y -f


### PR DESCRIPTION
User [cjsin](https://github.com/cjsin) noted that the URL for Gp6.deb has changed. Author [aviggiano](https://github.com/aviggiano) welcomed pull requests, but none had been made in four years. Here's the pull request. I have verified on my local machine that with change build succeeds. 

EDIT: Forgot to thank the author for the fantastic work. Thanks! :) 